### PR TITLE
 Fix lazy state cloning so that it is actually lazy and optimize CardinalityConstraint

### DIFF
--- a/src/solver/Board.ts
+++ b/src/solver/Board.ts
@@ -146,7 +146,7 @@ export class Board {
         clone.constraintStates = this.constraintStates.slice();
         clone.constraintStateIsCloned = [];
         // We can't mutate `this` state either as there may be a clone which references it
-        this.constraintStateIsCloned = []
+        this.constraintStateIsCloned = [];
         clone.memos = this.memos;
         clone.logicalSteps = this.logicalSteps;
         return clone;

--- a/src/solver/Board.ts
+++ b/src/solver/Board.ts
@@ -143,8 +143,10 @@ export class Board {
         clone.regions = this.regions;
         clone.constraints = this.constraints.map(constraint => constraint.clone()); // Clone constraints that need backtracking state
         clone.constraintsFinalized = this.constraintsFinalized;
-        clone.constraintStates = this.constraintStates.map(state => state.clone());
-        clone.constraintStateIsCloned = new Array(this.constraintStates.length);
+        clone.constraintStates = this.constraintStates.slice();
+        clone.constraintStateIsCloned = [];
+        // We can't mutate `this` state either as there may be a clone which references it
+        this.constraintStateIsCloned = []
         clone.memos = this.memos;
         clone.logicalSteps = this.logicalSteps;
         return clone;


### PR DESCRIPTION
Door in the Archway (quadruple/LK/killer puzzle) timing actually got worse after fixing lazy state cloning (41s -> 44s), what had a bigger impact is the second commit to have an early exit in `enforce/enforceCandidateElim` (44s -> 30s).

I'm guessing that this is due to worse branch prediction, but not sure. Could be worth creating an "eagerly cloned constraint state", but I think it's probably right to keep the lazy cloning as a feature as constraints with very large states may benefit more from lazy cloning (e.g. perhaps OrConstraint)