### PR TITLE
Improve constraint init

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Board, SolveOptions } from './solver/Board';
 import { registerAllConstraints } from './solver/Constraint/ConstraintLoader';
 import { FPuzzlesBoard } from './solver/Constraint/FPuzzlesInterfaces';
 import ConstraintBuilder from './solver/ConstraintBuilder';
-import { CellMask, CellValue, minValue, valueBit, valuesList, valuesMask } from './solver/SolveUtility';
+import { CellIndex, CellMask, CellValue, minValue, valueBit, valuesList, valuesMask } from './solver/SolveUtility';
 
 export type ExpandedCandidates = ({ given: true; value: number } | number[])[];
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -319,13 +319,6 @@ class SudokuVariantSolver {
             }
         }
 
-        // Add constraints
-        if (!this.constraintBuilder.buildConstraints(boardData, board)) {
-            return null;
-        }
-
-        // At this point, all weak links should be added
-
         // Set the givens
         for (let i = 0; i < size; i++) {
             for (let j = 0; j < size; j++) {
@@ -374,6 +367,11 @@ class SudokuVariantSolver {
             }
         }
         board.nakedSingles = newNakedSingles;
+
+        // Add constraints
+        if (!this.constraintBuilder.buildConstraints(boardData, board)) {
+            return null;
+        }
 
         return board;
     }

--- a/src/solver/Board.ts
+++ b/src/solver/Board.ts
@@ -299,7 +299,7 @@ export class Board {
     initConstraints(isRepeat: boolean = false): boolean {
         if (this.constraints.length > 0) {
             let haveChange = false;
-            let initedConstraints: Map<Constraint, boolean> = new Map();
+            const initedConstraints: Map<Constraint, boolean> = new Map();
             do {
                 haveChange = false;
 

--- a/src/solver/Board.ts
+++ b/src/solver/Board.ts
@@ -216,7 +216,7 @@ export class Board {
     }
 
     maskStrictlyHigher(v: CellValue) {
-        return this.allValues ^ (1 << (v - 1));
+        return this.allValues ^ this.maskLowerOrEqual(v);
     }
 
     maskLowerOrEqual(v: CellValue) {
@@ -224,7 +224,7 @@ export class Board {
     }
 
     maskHigherOrEqual(v: CellValue) {
-        return this.allValues ^ ((1 << v) - 1);
+        return this.allValues ^ this.maskStrictlyLower(v);
     }
 
     maskBetweenInclusive(v1: CellValue, v2: CellValue) {

--- a/src/solver/Constraint/BetweenLineConstraint.ts
+++ b/src/solver/Constraint/BetweenLineConstraint.ts
@@ -33,16 +33,18 @@ class BetweenLineConstraint extends Constraint {
             return ConstraintResult.INVALID;
         }
 
-        const middleCellMasks = this.middle.map(cell => board.cells[cell] & board.allValues);
-        for (const middleMask of middleCellMasks) {
-            // Invalid if the middle cannot be between the ends
-            if (minValue(middleMask) >= maxValue(endMask1) || maxValue(middleMask) <= minValue(endMask0)) {
+        let changed = ConstraintResult.UNCHANGED;
+        for (const middleCell of this.middle) {
+            const res = board.keepCellMask(middleCell, board.maskBetweenInclusive(minValue(endMask0) + 1, maxValue(endMask1) - 1));
+            if (res === ConstraintResult.INVALID) {
                 return ConstraintResult.INVALID;
+            } else if (res === ConstraintResult.CHANGED) {
+                changed = ConstraintResult.CHANGED;
             }
         }
 
         if (isRepeat) {
-            return ConstraintResult.UNCHANGED;
+            return changed;
         }
 
         // ends[0] < middle < ends[1]

--- a/src/solver/Constraint/BetweenLineConstraint.ts
+++ b/src/solver/Constraint/BetweenLineConstraint.ts
@@ -1,7 +1,7 @@
 import { Board } from '../Board';
 import ConstraintBuilder from '../ConstraintBuilder';
 import { CandidateIndex, cellIndexFromName, cellName, maxValue, minValue } from '../SolveUtility';
-import { Constraint, ConstraintResult } from './Constraint';
+import { Constraint, ConstraintResult, InitResult } from './Constraint';
 import { FPuzzlesLines } from './FPuzzlesInterfaces';
 import { OrConstraint } from './OrConstraint';
 import { generateLEWeakLinks } from './WeakLinksConstraint';
@@ -60,6 +60,10 @@ class BetweenLineConstraint extends Constraint {
             board.addWeakLink(weakLink[0], weakLink[1]);
         }
         return ConstraintResult.CHANGED;
+    }
+
+    finalize(board: Board): InitResult {
+        return { result: ConstraintResult.UNCHANGED, deleteConstraints: [this] };
     }
 }
 

--- a/src/solver/Constraint/Constraint.ts
+++ b/src/solver/Constraint/Constraint.ts
@@ -8,6 +8,8 @@ export enum ConstraintResult {
     INVALID,
 }
 
+export type InitResult = ConstraintResult | { result: ConstraintResult; addConstraints?: Constraint[]; deleteConstraints?: Constraint[] };
+
 // Convenience class that constraint states can inherit from if they only need to be shallow-cloned
 export class ConstraintState {
     clone(): ConstraintState {
@@ -45,7 +47,7 @@ export class Constraint {
     //  - isRepeat is true if this is not the first time init has been called on this constraint
     // Never call board.setAsGiven from init as not all weak links have been added yet, so they may not be respected.
     //  - Instead, use board.keepCellMask(cell, valueBit(value)) so that it will be a naked single at the appropriate time.
-    init(board: Board, isRepeat: boolean): ConstraintResult {
+    init(board: Board, isRepeat: boolean): InitResult {
         return ConstraintResult.UNCHANGED;
     }
 

--- a/src/solver/Constraint/Constraint.ts
+++ b/src/solver/Constraint/Constraint.ts
@@ -41,7 +41,11 @@ export class Constraint {
 
     // Initialize the constraint on the board, which may modify the board
     // Adding weak links should be done here
-    // Returns a ConstraintResult
+    // Returns an InitResult, which is either a ConstraintResult or an object of the form:
+    //  { result: ConstraintResult;
+    //    addConstraints?: Constraint[];
+    //    deleteConstraints?: Constraint[];
+    //  }
     // init is called repeatedly on every constraint until all constraints return ConstraintResult.UNCHANGED
     //  - This allows constraints to interact with each other
     //  - isRepeat is true if this is not the first time init has been called on this constraint
@@ -53,8 +57,12 @@ export class Constraint {
 
     // Final initialization of the constraint on the board, which may NOT modify the board
     // finalize is called after all constraints have successfully been inited, so constraints may, for example, assume all weak links have been added.
-    // Returns either ConstraintResult.UNCHANGED or ConstraintResult.INVALID
-    finalize(board: Board): ConstraintResult {
+    // The returned ConstraintResult must not be CHANGED, as it may not modify the board.
+    // Constraints may not be added here. However, as an exception, constraints may be deleted here.
+    //  { result: ConstraintResult;
+    //    deleteConstraints?: Constraint[];
+    //  }
+    finalize(board: Board): InitResult {
         return ConstraintResult.UNCHANGED;
     }
 

--- a/src/solver/Constraint/GeneralCellPairConstraint.ts
+++ b/src/solver/Constraint/GeneralCellPairConstraint.ts
@@ -1,7 +1,7 @@
 import { Board } from '../Board';
 import ConstraintBuilder from '../ConstraintBuilder';
 import { CellIndex, cellIndexFromName, hasValue, valueBit } from '../SolveUtility';
-import { Constraint, ConstraintResult } from './Constraint';
+import { Constraint, ConstraintResult, InitResult } from './Constraint';
 import { FPuzzlesBoard } from './FPuzzlesInterfaces';
 
 export type IsPairAllowedFn = (value1: number, value2: number) => boolean;
@@ -11,6 +11,7 @@ export interface GeneralCellPairConstraintParams {
     cellPairs: [CellIndex, CellIndex][];
 }
 
+// TODO: Remove and replace existing uses with weak links
 export class GeneralCellPairConstraint extends Constraint {
     cellPairs: [CellIndex, CellIndex][];
     cellPairKeys: number[];
@@ -152,6 +153,10 @@ export class GeneralCellPairConstraint extends Constraint {
         }
 
         return changed ? ConstraintResult.CHANGED : ConstraintResult.UNCHANGED;
+    }
+
+    finalize(board: Board): InitResult {
+        return { result: ConstraintResult.UNCHANGED, deleteConstraints: [this] };
     }
 }
 

--- a/src/solver/Constraint/OrConstraint.ts
+++ b/src/solver/Constraint/OrConstraint.ts
@@ -95,19 +95,7 @@ export class OrConstraint extends Constraint {
     }
 
     finalize() {
-        this.subboards = this.subboards.filter(subboard => {
-            for (const constraint of subboard.constraints) {
-                const result = constraint.finalize(subboard);
-                if (result === ConstraintResult.INVALID) {
-                    return false;
-                }
-                if (result === ConstraintResult.CHANGED) {
-                    throw new Error('finalize is not allowed to change the board');
-                }
-            }
-            subboard.constraintsFinalized = true;
-            return true;
-        });
+        this.subboards = this.subboards.filter(subboard => subboard.finalizeConstraintsNoInit());
 
         // No more subboards left == puzzle is broken
         return this.subboards.length === 0 ? ConstraintResult.INVALID : ConstraintResult.UNCHANGED;

--- a/src/solver/Constraint/OrConstraint.ts
+++ b/src/solver/Constraint/OrConstraint.ts
@@ -1,6 +1,6 @@
 import { Board } from '../Board';
 import { valueBit, minValue, CellIndex, CellValue, CandidateIndex } from '../SolveUtility';
-import { Constraint, ConstraintResult } from './Constraint';
+import { Constraint, ConstraintResult, InitResult } from './Constraint';
 
 interface OrConstraintParams {
     subboards: Board[];
@@ -12,14 +12,21 @@ export class OrConstraint extends Constraint {
     subboards: Board[];
 
     constructor(constraintName: string, specificName: string, board: Board, params: OrConstraintParams) {
-        const { subboards } = params;
-        super(board, constraintName, specificName);
-        this.numCells = board.size * board.size;
-        this.numCandidates = board.size * board.size * board.size;
-        this.subboards = subboards;
+        if (constraintName === undefined || specificName === undefined || board === undefined || params === undefined) {
+            super(undefined, undefined, undefined);
+            this.numCells = undefined;
+            this.numCandidates = undefined;
+            this.subboards = undefined;
+        } else {
+            const { subboards } = params;
+            super(board, constraintName, specificName);
+            this.numCells = board.size * board.size;
+            this.numCandidates = board.size * board.size * board.size;
+            this.subboards = subboards;
+        }
     }
 
-    init(board: Board, isRepeat: boolean) {
+    init(board: Board, isRepeat: boolean): InitResult {
         this.subboards = this.subboards.filter(subboard => {
             // Copy state downwards
             for (let cellIndex = 0; cellIndex < this.numCells; ++cellIndex) {
@@ -79,6 +86,11 @@ export class OrConstraint extends Constraint {
             }
         }
 
+        // Only a single subboard, send up all our constraints onto the main board and delete ourselves
+        if (this.subboards.length === 1) {
+            return { result: changed, addConstraints: this.subboards[0].constraints.slice(), deleteConstraints: [this] };
+        }
+
         return changed;
     }
 
@@ -103,7 +115,7 @@ export class OrConstraint extends Constraint {
 
     clone() {
         // Shallow copy everything
-        const clone = Object.assign(Object.create(Object.getPrototypeOf(this)), this);
+        const clone = Object.assign(new OrConstraint(undefined, undefined, undefined, undefined), this);
 
         // Clone each subboard
         clone.subboards = this.subboards.map(subboard => subboard.clone());

--- a/src/solver/Constraint/RegionConstraint.ts
+++ b/src/solver/Constraint/RegionConstraint.ts
@@ -1,7 +1,7 @@
 import { Board } from '../Board';
 import ConstraintBuilder from '../ConstraintBuilder';
 import { CellIndex, cellIndexFromName, cellName } from '../SolveUtility';
-import { Constraint, ConstraintResult } from './Constraint';
+import { Constraint, ConstraintResult, InitResult } from './Constraint';
 import { FPuzzlesCells } from './FPuzzlesInterfaces';
 
 export interface RegionConstraintParams {
@@ -17,15 +17,11 @@ export class RegionConstraint extends Constraint {
         this.cells = params.cells.slice();
     }
 
-    init(board: Board, isRepeat: boolean): ConstraintResult {
-        if (isRepeat) {
-            return ConstraintResult.UNCHANGED;
-        }
-
-        if (board.addRegion(this.specificName, this.cells, this.constraintName)) {
-            return ConstraintResult.CHANGED;
-        }
-        return ConstraintResult.UNCHANGED;
+    init(board: Board, isRepeat: boolean): InitResult {
+        return {
+            result: board.addRegion(this.specificName, this.cells, this.constraintName) ? ConstraintResult.CHANGED : ConstraintResult.UNCHANGED,
+            deleteConstraints: [this],
+        };
     }
 }
 

--- a/src/solver/Constraint/WeakLinksConstraint.ts
+++ b/src/solver/Constraint/WeakLinksConstraint.ts
@@ -1,6 +1,6 @@
 import { Board } from '../Board';
 import { CandidateIndex, CellIndex, valueBit } from '../SolveUtility';
-import { Constraint, ConstraintResult } from './Constraint';
+import { Constraint, ConstraintResult, InitResult } from './Constraint';
 
 export interface WeakLinksConstraintParams {
     weakLinks: [CandidateIndex, CandidateIndex][];
@@ -15,11 +15,7 @@ export class WeakLinksConstraint extends Constraint {
         this.weakLinks = params.weakLinks.slice();
     }
 
-    init(board: Board, isRepeat: boolean): ConstraintResult {
-        if (isRepeat) {
-            return ConstraintResult.UNCHANGED;
-        }
-
+    init(board: Board, isRepeat: boolean): InitResult {
         let changed = false;
         for (const [candidate1, candidate2] of this.weakLinks) {
             if (candidate1 === candidate2) {
@@ -35,7 +31,7 @@ export class WeakLinksConstraint extends Constraint {
                 changed = changed || added;
             }
         }
-        return changed ? ConstraintResult.CHANGED : ConstraintResult.UNCHANGED;
+        return { result: changed ? ConstraintResult.CHANGED : ConstraintResult.UNCHANGED, deleteConstraints: [this] };
     }
 }
 


### PR DESCRIPTION
Allow constraints to add or delete constraints during init / finalize.
Set givens before initializing constraints so more propagations are made during init.
(and also make betweenline eliminate middle cell candidates so they're restricted to the outer range)