### PR TITLE
Make BIG subboardclone faster by making the arrays sparse

### DIFF
--- a/src/solver/BinaryImplicationLayeredGraph.ts
+++ b/src/solver/BinaryImplicationLayeredGraph.ts
@@ -142,7 +142,7 @@ class BinaryImplicationGraph {
     }
 
     hasImplication(lit1: Literal, lit2: Literal): boolean {
-        return (this.implicationsArrFor(lit1, lit2) ?? []).includes(toVariable(lit2));
+        return this.implicationsArrFor(lit1, lit2)?.includes(toVariable(lit2));
     }
 
     getPosConsequences(lit: Literal, consequentsOutput: Variable[]) {

--- a/src/solver/BinaryImplicationLayeredGraph.ts
+++ b/src/solver/BinaryImplicationLayeredGraph.ts
@@ -97,7 +97,7 @@ class BinaryImplicationGraph {
     addImplication(lit1: Literal, lit2: Literal): boolean {
         let forward = this.implicationsArrFor(lit1, lit2);
         const var2 = toVariable(lit2);
-        if ((forward ?? []).includes(var2)) {
+        if (forward?.includes(var2)) {
             return false;
         }
         if (forward === undefined) {
@@ -128,13 +128,13 @@ class BinaryImplicationGraph {
     //  - No preprocessing has been done yet, so removing this implication doesn't invalidate any transitive implications.
     //  - We're transferring an implication to a parent, so the semantics of the graph have not actually changed at all.
     unsafeRemoveImplication(lit1: Literal, lit2: Literal): boolean {
-        const forward = this.implicationsArrFor(lit1, lit2) ?? [];
+        const forward = this.implicationsArrFor(lit1, lit2);
         const var2 = toVariable(lit2);
-        if (!forward.includes(var2)) {
+        if (!forward?.includes(var2)) {
             return false;
         }
         const var1 = toVariable(lit1);
-        const backward = this.implicationsArrFor(~lit2, ~lit1) ?? [];
+        const backward = this.implicationsArrFor(~lit2, ~lit1);
         // Preserves sortedness, no need to add to unsortedArr
         sequenceFilterOutUpdateDefaultCompare(forward, [var2], []);
         sequenceFilterOutUpdateDefaultCompare(backward, [var1], []);
@@ -146,31 +146,45 @@ class BinaryImplicationGraph {
     }
 
     getPosConsequences(lit: Literal, consequentsOutput: Variable[]) {
-        for (const consequent of this.implicationsArrFor(lit, 0) ?? []) {
-            consequentsOutput.push(consequent);
+        const consequents = this.implicationsArrFor(lit, 0);
+        if (consequents) {
+            for (const consequent of consequents) {
+                consequentsOutput.push(consequent);
+            }
         }
     }
 
     getNegConsequences(lit: Literal, consequentsOutput: Variable[]) {
-        for (const consequent of this.implicationsArrFor(lit, ~0) ?? []) {
-            consequentsOutput.push(consequent);
+        const consequents = this.implicationsArrFor(lit, ~0);
+        if (consequents) {
+            for (const consequent of consequents) {
+                consequentsOutput.push(consequent);
+            }
         }
     }
 
     filterOutPosConsequences(lit: Literal, consequentsInout: Variable[], filteredOut: Variable[]) {
-        sequenceFilterOutUpdateDefaultCompare(consequentsInout, this.implicationsArrFor(lit, 0) ?? [], filteredOut);
+        const consequents = this.implicationsArrFor(lit, 0);
+        if (consequents) {
+            sequenceFilterOutUpdateDefaultCompare(consequentsInout, consequents, filteredOut);
+        }
     }
 
     filterOutNegConsequences(lit: Literal, consequentsInout: Variable[], filteredOut: Variable[]) {
-        sequenceFilterOutUpdateDefaultCompare(consequentsInout, this.implicationsArrFor(lit, ~0) ?? [], filteredOut);
+        const consequents = this.implicationsArrFor(lit, ~0);
+        if (consequents) {
+            sequenceFilterOutUpdateDefaultCompare(consequentsInout, consequents, filteredOut);
+        }
     }
 
     hasAnyCommonPosConsequences(lit: Literal, consequents: Variable[]): boolean {
-        return sequenceHasNonemptyIntersectionDefaultCompare(consequents, this.implicationsArrFor(lit, 0) ?? []);
+        const litConsequents = this.implicationsArrFor(lit, 0);
+        return litConsequents && sequenceHasNonemptyIntersectionDefaultCompare(consequents, litConsequents);
     }
 
     hasAnyCommonNegConsequences(lit: Literal, consequents: Variable[]): boolean {
-        return sequenceHasNonemptyIntersectionDefaultCompare(consequents, this.implicationsArrFor(lit, ~0) ?? []);
+        const litConsequents = this.implicationsArrFor(lit, ~0);
+        return litConsequents && sequenceHasNonemptyIntersectionDefaultCompare(consequents, litConsequents);
     }
 }
 
@@ -309,7 +323,9 @@ export class BinaryImplicationLayeredGraph {
             // TODO: Remove all the removeDuplicate once the BIG is properly deduplicated and sorted
             return removeDuplicates(this.getPosConsequences(lits[0]).sort((a, b) => a - b));
         }
+        lits.push(1); // key for "pos consequences"
         const memoKey = appendInts(lits);
+        lits.pop();
         const memoResult = this.getMemo(memoKey);
         if (memoResult !== undefined) {
             return memoResult;
@@ -335,7 +351,9 @@ export class BinaryImplicationLayeredGraph {
             // TODO: Remove all the removeDuplicate once the BIG is properly deduplicated and sorted
             return removeDuplicates(this.getNegConsequences(lits[0]).sort((a, b) => a - b));
         }
+        lits.push(0); // key for "neg consequences"
         const memoKey = appendInts(lits);
+        lits.pop();
         const memoResult = this.getMemo(memoKey);
         if (memoResult !== undefined) {
             return memoResult;


### PR DESCRIPTION
It's preprocessing only but still took a large part of the solve (0.1s) for subboard heavy clues like Sandwich Sum.

Before: 190.6ms in `BinaryImplicationLayeredGraph.subboardClone` over 2 solves
Before: 7.0ms in `BinaryImplicationLayeredGraph.subboardClone` over 2 solves