### PR TITLE
Fix bug where cell forcing LUTs were not being recomputed when implications are added to a parent layer

### DIFF
--- a/src/solver/Constraint/OrConstraint.ts
+++ b/src/solver/Constraint/OrConstraint.ts
@@ -190,7 +190,7 @@ export class OrConstraint extends Constraint {
             board.binaryImplications.filterOutNegConsequences(candidate, newLinks, scratch);
             for (const link of scratch) {
                 for (const subboard of this.subboards) {
-                    subboard.binaryImplications.graph.unsafeRemoveImplication(candidate, ~link);
+                    subboard.binaryImplications.transferImplicationToParent(candidate, ~link);
                 }
             }
             for (const link of newLinks) {


### PR DESCRIPTION
While we're at it, make the recomputation more granular so if a literal didn't update, we can skip recomputing masks which don't overlap at all with that literal. e.g. if only the first 3 literals of a 6 length clause updated, we can skip recomputing the subclauses 456, 45, 56, 46