### PR TITLE
keepCellMask/setAsGiven refactor and only trigger constraints for cells that updated

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -433,9 +433,6 @@ class SudokuVariantSolver {
             board.setAsGiven(given, value);
         }
 
-        // Clean up any naked singles which are alreay set as given
-        board.nakedSingles = board.nakedSingles.filter(cellIndex => !board.isGiven(cellIndex));
-
         return board;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { Board, SolveOptions, SolveStats } from './solver/Board';
+import { ConstraintResult } from './solver/Constraint/Constraint';
 import { registerAllConstraints } from './solver/Constraint/ConstraintLoader';
 import { FPuzzlesBoard } from './solver/Constraint/FPuzzlesInterfaces';
 import ConstraintBuilder from './solver/ConstraintBuilder';
@@ -339,7 +340,7 @@ class SudokuVariantSolver {
                 const cellIndex = board.cellIndex(i, j);
                 if (keepPencilMarks) {
                     if (srcCell.value) {
-                        if (!board.enforceValue(cellIndex, srcCell.value)) {
+                        if (board.newApplyCellMask(cellIndex, valueBit(srcCell.value)) === ConstraintResult.INVALID) {
                             return null;
                         }
                         givenSingles.push([cellIndex, srcCell.value]);
@@ -359,7 +360,7 @@ class SudokuVariantSolver {
                     }
                 } else {
                     if (srcCell.given) {
-                        if (!board.enforceValue(cellIndex, srcCell.value)) {
+                        if (board.newApplyCellMask(cellIndex, valueBit(srcCell.value)) === ConstraintResult.INVALID) {
                             return null;
                         }
                         givenSingles.push([cellIndex, srcCell.value]);
@@ -430,7 +431,7 @@ class SudokuVariantSolver {
 
         // setAsGiven the given singles to set givenBit / enforce constraints
         for (const [given, value] of givenSingles) {
-            board.setAsGiven(given, value);
+            board.newApplySingle(board.candidateIndex(given, value));
         }
 
         return board;

--- a/src/index.ts
+++ b/src/index.ts
@@ -340,7 +340,7 @@ class SudokuVariantSolver {
                 const cellIndex = board.cellIndex(i, j);
                 if (keepPencilMarks) {
                     if (srcCell.value) {
-                        if (board.newApplyCellMask(cellIndex, valueBit(srcCell.value)) === ConstraintResult.INVALID) {
+                        if (board.applyCellMask(cellIndex, valueBit(srcCell.value)) === ConstraintResult.INVALID) {
                             return null;
                         }
                         givenSingles.push([cellIndex, srcCell.value]);
@@ -360,7 +360,7 @@ class SudokuVariantSolver {
                     }
                 } else {
                     if (srcCell.given) {
-                        if (board.newApplyCellMask(cellIndex, valueBit(srcCell.value)) === ConstraintResult.INVALID) {
+                        if (board.applyCellMask(cellIndex, valueBit(srcCell.value)) === ConstraintResult.INVALID) {
                             return null;
                         }
                         givenSingles.push([cellIndex, srcCell.value]);
@@ -431,7 +431,7 @@ class SudokuVariantSolver {
 
         // setAsGiven the given singles to set givenBit / enforce constraints
         for (const [given, value] of givenSingles) {
-            board.newApplySingle(board.candidateIndex(given, value));
+            board.applySingle(board.candidateIndex(given, value));
         }
 
         return board;

--- a/src/solver/Constraint/ArrowSumConstraint.ts
+++ b/src/solver/Constraint/ArrowSumConstraint.ts
@@ -57,7 +57,7 @@ export class ArrowSumConstraint extends Constraint {
             const subboards = [];
             for (let tensDigit = 1; tensDigit <= board.size; ++tensDigit) {
                 const subboard = board.subboardClone();
-                subboard.keepCellMask(this.circleCells[0], valueBit(tensDigit));
+                subboard.newApplyCellMask(this.circleCells[0], valueBit(tensDigit));
                 subboard.addConstraint(
                     new EqualSumConstraint(
                         `Hypothetical ${this.toString()}`,
@@ -79,7 +79,7 @@ export class ArrowSumConstraint extends Constraint {
     }
 
     // eslint-disable-next-line no-unused-vars
-    initPill(board: Board) {
+    initPill(board: Board): ConstraintResult {
         const [sumMin, sumMax] = this.arrowCellsSum.sumRange(board);
         const sumMinLength = sumMin.toString().length;
         const sumMaxLength = sumMax.toString().length;
@@ -105,8 +105,7 @@ export class ArrowSumConstraint extends Constraint {
             }
 
             const firstCircleCell = this.circleCells[0];
-            const keepResult = board.keepCellMask(firstCircleCell, board.maskBetweenInclusive(minSumLeadingDigit, maxSumLeadingDigit));
-            return keepResult;
+            return board.newApplyCellMask(firstCircleCell, board.maskBetweenInclusive(minSumLeadingDigit, maxSumLeadingDigit));
         }
 
         const maxDigitLength = board.size.toString().length;

--- a/src/solver/Constraint/ArrowSumConstraint.ts
+++ b/src/solver/Constraint/ArrowSumConstraint.ts
@@ -58,7 +58,7 @@ export class ArrowSumConstraint extends Constraint {
             const subboards = [];
             for (let tensDigit = 1; tensDigit <= board.size; ++tensDigit) {
                 const subboard = board.subboardClone();
-                subboard.newApplyCellMask(this.circleCells[0], valueBit(tensDigit));
+                subboard.applyCellMask(this.circleCells[0], valueBit(tensDigit));
                 subboard.addConstraint(
                     new EqualSumConstraint(
                         `Hypothetical ${this.toString()}`,
@@ -106,7 +106,7 @@ export class ArrowSumConstraint extends Constraint {
             }
 
             const firstCircleCell = this.circleCells[0];
-            return board.newApplyCellMask(firstCircleCell, board.maskBetweenInclusive(minSumLeadingDigit, maxSumLeadingDigit));
+            return board.applyCellMask(firstCircleCell, board.maskBetweenInclusive(minSumLeadingDigit, maxSumLeadingDigit));
         }
 
         const maxDigitLength = board.size.toString().length;

--- a/src/solver/Constraint/ArrowSumConstraint.ts
+++ b/src/solver/Constraint/ArrowSumConstraint.ts
@@ -21,14 +21,15 @@ export class ArrowSumConstraint extends Constraint {
 
     constructor(board: Board, params: ArrowSumConstraintParams) {
         const specificName = `Arrow at ${cellName(params.circleCells[0], board.size)}`;
-        super('Arrow', specificName);
+        const allCells = [...params.circleCells, ...params.arrowCells];
+        super('Arrow', specificName, allCells);
 
         this.circleCells = params.circleCells.slice();
 
         this.arrowCells = params.arrowCells.slice();
         this.arrowCellsSum = new SumCellsHelper(board, this.arrowCells);
 
-        this.allCells = [...this.circleCells, ...this.arrowCells];
+        this.allCells = allCells;
         this.allCellsSet = new Set(this.allCells);
     }
 
@@ -70,7 +71,7 @@ export class ArrowSumConstraint extends Constraint {
             }
             return {
                 result: ConstraintResult.UNCHANGED,
-                addConstraints: [new OrConstraint(this.constraintName, this.specificName, board, { subboards })],
+                addConstraints: [new OrConstraint(this.constraintName, this.specificName, board, { subboards, cells: this.allCells.slice() })],
                 deleteConstraints: [this],
             };
         }

--- a/src/solver/Constraint/BetweenLineConstraint.ts
+++ b/src/solver/Constraint/BetweenLineConstraint.ts
@@ -18,7 +18,7 @@ class BetweenLineConstraint extends Constraint {
 
     constructor(board: Board, params: BetweenLineParams) {
         const specificName = `Between Line at ${cellName(params.ends[0], board.size)} - ${cellName(params.ends[1], board.size)}`;
-        super('Between Line', specificName);
+        super('Between Line', specificName, [...params.ends, ...params.middle]);
 
         this.ends = params.ends;
         this.middle = params.middle.slice();
@@ -93,7 +93,10 @@ export function register(constraintBuilder: ConstraintBuilder) {
             const subboard2 = board.subboardClone();
             subboard2.addConstraint(new BetweenLineConstraint(board, { ends: [outer[1], outer[0]], middle: middle }));
             return [
-                new OrConstraint('Between Line', `Between Line at ${line[0]}-${line[line.length - 1]}`, board, { subboards: [subboard1, subboard2] }),
+                new OrConstraint('Between Line', `Between Line at ${line[0]}-${line[line.length - 1]}`, board, {
+                    subboards: [subboard1, subboard2],
+                    cells: [...outer, ...middle],
+                }),
             ];
         })
     );

--- a/src/solver/Constraint/CardinalityConstraint.ts
+++ b/src/solver/Constraint/CardinalityConstraint.ts
@@ -1,5 +1,5 @@
 import { Board, ReadonlyBoard } from '../Board';
-import { CandidateIndex, CellIndex, CellValue, StateKey, valueBit } from '../SolveUtility';
+import { CandidateIndex, CellIndex, CellValue, StateKey, removeDuplicates, valueBit } from '../SolveUtility';
 import { Constraint, ConstraintResult, InitResult, LogicalDeduction } from './Constraint';
 
 class CardinalityConstraintState {
@@ -35,7 +35,11 @@ export class CardinalityConstraint extends Constraint {
     stateKey: StateKey<CardinalityConstraintState>;
 
     constructor(constraintName: string, specificName: string, board: Board, params: CardinalityConstraintParams) {
-        super(constraintName, specificName);
+        super(
+            constraintName,
+            specificName,
+            params.candidates.map(candidate => board.cellIndexFromCandidate(candidate))
+        );
 
         // Check that candidates contains no duplicates
         for (let i = 0; i < params.candidates.length - 1; ++i) {
@@ -79,6 +83,7 @@ export class CardinalityConstraint extends Constraint {
             // Naked singles will get enforced later, so it's ok to ignore them for now
             return true;
         });
+        this.constraintCells = removeDuplicates(state.candidates.map(candidate => board.cellIndexFromCandidate(candidate)).sort((a, b) => a - b));
 
         if (state.candidates.length === 0) {
             // No candidates means we're either always satisfied or we're always broken. Either way we can delete ourselves.
@@ -298,6 +303,4 @@ export class CardinalityConstraint extends Constraint {
 
         return [];
     }
-
-    // TODO: Implement bruteForceStep and make it skip clause forcing (check if this speeds up solves)
 }

--- a/src/solver/Constraint/Constraint.ts
+++ b/src/solver/Constraint/Constraint.ts
@@ -159,17 +159,10 @@ export class Constraint {
         if (deductions.invalid) {
             return ConstraintResult.INVALID;
         }
-        if (deductions.singles && deductions.singles.length > 0) {
-            if (!board.enforceCandidates(deductions.singles)) {
-                return ConstraintResult.INVALID;
-            }
-            changed = ConstraintResult.CHANGED;
-        }
-        if (deductions.eliminations && deductions.eliminations.length > 0) {
-            if (!board.clearCandidates(deductions.eliminations)) {
-                return ConstraintResult.INVALID;
-            }
-            changed = ConstraintResult.CHANGED;
+        if ((deductions.singles && deductions.singles.length > 0) || (deductions.eliminations && deductions.eliminations.length > 0)) {
+            const result = board.applyAndPropagate(deductions.eliminations ?? [], deductions.singles ?? []);
+            if (result === ConstraintResult.INVALID) return ConstraintResult.INVALID;
+            if (result === ConstraintResult.CHANGED) changed = ConstraintResult.CHANGED;
         }
         // Don't apply any weak links or constraint modifications in bruteForceStep since that's not allowed here
 
@@ -197,17 +190,10 @@ export class Constraint {
         if (deductions.invalid) {
             return ConstraintResult.INVALID;
         }
-        if (deductions.singles && deductions.singles.length > 0) {
-            if (!board.enforceCandidates(deductions.singles)) {
-                return ConstraintResult.INVALID;
-            }
-            changed = ConstraintResult.CHANGED;
-        }
-        if (deductions.eliminations && deductions.eliminations.length > 0) {
-            if (!board.clearCandidates(deductions.eliminations)) {
-                return ConstraintResult.INVALID;
-            }
-            changed = ConstraintResult.CHANGED;
+        if ((deductions.singles && deductions.singles.length > 0) || (deductions.eliminations && deductions.eliminations.length > 0)) {
+            const result = board.applyAndPropagate(deductions.eliminations ?? [], deductions.singles ?? []);
+            if (result === ConstraintResult.INVALID) return ConstraintResult.INVALID;
+            if (result === ConstraintResult.CHANGED) changed = ConstraintResult.CHANGED;
         }
 
         return {

--- a/src/solver/Constraint/Constraint.ts
+++ b/src/solver/Constraint/Constraint.ts
@@ -1,5 +1,5 @@
 import { Board, ReadonlyBoard } from '../Board';
-import { CandidateIndex, CellCoords, CellIndex, CellValue, Implication, WeakLink } from '../SolveUtility';
+import { CandidateIndex, CellCoords, CellIndex, CellValue, Implication, WeakLink, removeDuplicates } from '../SolveUtility';
 
 // Reflects what has happened to the board
 export enum ConstraintResult {
@@ -55,15 +55,15 @@ export class ConstraintState {
 export class Constraint {
     constraintName: string;
     specificName: string;
-    isConstraintV2: true; // Temporary hack that we'll remove once everything is on ConstraintV2
+    constraintCells: CellIndex[];
 
     // The constraintName is a string that is used to identify the constraint
     // The specificName is a string that is specific to this constraint instance
     // board should NOT be modified at this time. Initialization should happen in `init` instead.
-    constructor(constraintName: string, specificName: string) {
+    constructor(constraintName: string, specificName: string, constraintCells: CellIndex[]) {
         this.constraintName = constraintName;
         this.specificName = specificName;
-        this.isConstraintV2 = true;
+        this.constraintCells = constraintCells === undefined ? undefined : removeDuplicates(constraintCells.toSorted((a, b) => a - b));
     }
 
     ///////////////

--- a/src/solver/Constraint/EqualSumConstraint.ts
+++ b/src/solver/Constraint/EqualSumConstraint.ts
@@ -19,7 +19,7 @@ export class EqualSumConstraint extends Constraint {
     helpers: SumCellsHelper[];
 
     constructor(constraintName: string, specificName: string, board: Board, params: { cells: CellIndex[][]; offsets?: number[] }) {
-        super(constraintName, specificName);
+        super(constraintName, specificName, params.cells.flat());
 
         this.cells = [];
         this.offsets = [];
@@ -63,7 +63,7 @@ export class EqualSumConstraint extends Constraint {
                     })
                 );
             }
-            return { result: ConstraintResult.UNCHANGED, addConstraints, deleteConstraints: [this] };
+            return { result: ConstraintResult.UNCHANGED, addConstraints, deleteConstraints: [this] as Constraint[] };
         }
 
         return ConstraintResult.UNCHANGED;

--- a/src/solver/Constraint/FixedSumConstraint.ts
+++ b/src/solver/Constraint/FixedSumConstraint.ts
@@ -15,7 +15,7 @@ export class FixedSumConstraint extends Constraint {
     sumHelper: SumCellsHelper;
 
     constructor(constraintName: string, specificName: string, board: Board, params: FixedSumConstraintParams) {
-        super(constraintName, specificName);
+        super(constraintName, specificName, params.cells.slice());
 
         this.sum = params.sum;
         this.cells = params.cells.toSorted((a: number, b: number) => a - b);

--- a/src/solver/Constraint/FixedSumConstraint.ts
+++ b/src/solver/Constraint/FixedSumConstraint.ts
@@ -32,7 +32,7 @@ export class FixedSumConstraint extends Constraint {
 
             const cell = this.cells[0];
             return {
-                result: board.keepCellMask(cell, valueBit(this.sum)),
+                result: board.newApplyCellMask(cell, valueBit(this.sum)),
                 deleteConstraints: [this],
             };
         }

--- a/src/solver/Constraint/FixedSumConstraint.ts
+++ b/src/solver/Constraint/FixedSumConstraint.ts
@@ -32,7 +32,7 @@ export class FixedSumConstraint extends Constraint {
 
             const cell = this.cells[0];
             return {
-                result: board.newApplyCellMask(cell, valueBit(this.sum)),
+                result: board.applyCellMask(cell, valueBit(this.sum)),
                 deleteConstraints: [this],
             };
         }

--- a/src/solver/Constraint/InvalidConstraint.ts
+++ b/src/solver/Constraint/InvalidConstraint.ts
@@ -3,7 +3,7 @@ import { Constraint, ConstraintResult } from './Constraint';
 
 export class InvalidConstraint extends Constraint {
     constructor(board: Board, constraintName: string, specificName: string) {
-        super(constraintName, specificName);
+        super(constraintName, specificName, []);
     }
 
     init(board: Board) {

--- a/src/solver/Constraint/LockoutConstraint.ts
+++ b/src/solver/Constraint/LockoutConstraint.ts
@@ -118,7 +118,7 @@ export function register(constraintBuilder: ConstraintBuilder) {
                 )
             );
 
-            return new OrConstraint('Lockout', `Lockout at ${line[0]}`, board, { subboards: [subboard1, subboard2] });
+            return new OrConstraint('Lockout', `Lockout at ${line[0]}`, board, { subboards: [subboard1, subboard2], cells: [...outer, ...middle] });
         })
     );
 }

--- a/src/solver/Constraint/OrConstraint.ts
+++ b/src/solver/Constraint/OrConstraint.ts
@@ -4,6 +4,7 @@ import { Constraint, ConstraintResult, InitResult, LogicalDeduction } from './Co
 
 interface OrConstraintParams {
     subboards: Board[];
+    cells: CellIndex[];
 }
 
 export class OrConstraint extends Constraint {
@@ -14,14 +15,14 @@ export class OrConstraint extends Constraint {
 
     constructor(constraintName: string, specificName: string, board: Board, params: OrConstraintParams) {
         if (constraintName === undefined || specificName === undefined || board === undefined || params === undefined) {
-            super(undefined, undefined);
+            super(undefined, undefined, undefined);
             this.numCells = undefined;
             this.numCandidates = undefined;
             this.subboards = undefined;
             this.subboardsChanged = undefined;
         } else {
-            const { subboards } = params;
-            super(constraintName, specificName);
+            const { subboards, cells } = params;
+            super(constraintName, specificName, cells);
             this.numCells = board.size * board.size;
             this.numCandidates = board.size * board.size * board.size;
             this.subboards = subboards;
@@ -61,7 +62,7 @@ export class OrConstraint extends Constraint {
 
     clone() {
         // Shallow copy everything
-        const clone = Object.assign(new OrConstraint(undefined, undefined, undefined, undefined), this);
+        const clone: OrConstraint = Object.assign(new OrConstraint(undefined, undefined, undefined, undefined), this);
 
         // Clone each subboard
         clone.subboards = this.subboards.map(subboard => subboard.clone());
@@ -196,6 +197,11 @@ export class OrConstraint extends Constraint {
             for (const link of scratch) {
                 for (const subboard of this.subboards) {
                     subboard.binaryImplications.transferImplicationToParent(candidate, ~link);
+                }
+            }
+            if (scratch.length > 0) {
+                for (const constraint of board.constraints) {
+                    constraint.constraintCells[0] !== undefined && board.markCellAsModified(constraint.constraintCells[0]);
                 }
             }
             for (const link of newLinks) {

--- a/src/solver/Constraint/OrConstraint.ts
+++ b/src/solver/Constraint/OrConstraint.ts
@@ -34,7 +34,7 @@ export class OrConstraint extends Constraint {
         this.subboards = this.subboards.filter(subboard => {
             // Copy state downwards
             if (
-                subboard.newApplyCellMasks(
+                subboard.applyCellMasks(
                     Array.from({ length: this.numCells }, (_, i) => i),
                     board.cells
                 ) === ConstraintResult.INVALID
@@ -80,7 +80,7 @@ export class OrConstraint extends Constraint {
         this.subboardsChanged = true;
         let invalidSubboards: Board[] | null = null;
         for (const subboard of this.subboards) {
-            if (subboard.newApplySingle(board.candidateIndex(cellIndex, value)) === ConstraintResult.INVALID) {
+            if (subboard.applySingle(board.candidateIndex(cellIndex, value)) === ConstraintResult.INVALID) {
                 if (invalidSubboards === null) {
                     invalidSubboards = [];
                 }
@@ -99,7 +99,7 @@ export class OrConstraint extends Constraint {
         this.subboardsChanged = true;
         let invalidSubboards: Board[] | null = null;
         for (const subboard of this.subboards) {
-            if (subboard.newApplyElim(board.candidateIndex(cellIndex, value)) === ConstraintResult.INVALID) {
+            if (subboard.applyElim(board.candidateIndex(cellIndex, value)) === ConstraintResult.INVALID) {
                 if (invalidSubboards === null) {
                     invalidSubboards = [];
                 }
@@ -275,7 +275,7 @@ export class OrConstraint extends Constraint {
             sharedMasks.push(cellMask);
         }
 
-        return board.newApplyCellMasks(
+        return board.applyCellMasks(
             Array.from({ length: this.numCells }, (_, i) => i),
             sharedMasks
         );

--- a/src/solver/Constraint/RegionConstraint.ts
+++ b/src/solver/Constraint/RegionConstraint.ts
@@ -12,7 +12,7 @@ export class RegionConstraint extends Constraint {
     cells: CellIndex[];
 
     constructor(board: Board, params: RegionConstraintParams, name: string, specificName: string) {
-        super(name, specificName);
+        super(name, specificName, params.cells.slice());
 
         this.cells = params.cells.slice();
     }

--- a/src/solver/Constraint/RenbanConstraint.ts
+++ b/src/solver/Constraint/RenbanConstraint.ts
@@ -123,7 +123,7 @@ class RenbanConstraint extends Constraint {
         }
 
         let changed = ConstraintResult.UNCHANGED;
-        const result = board.newApplyCellMasks(
+        const result = board.applyCellMasks(
             this.cells,
             Array.from({ length: this.cells.length }, () => expand)
         );

--- a/src/solver/Constraint/RenbanConstraint.ts
+++ b/src/solver/Constraint/RenbanConstraint.ts
@@ -11,7 +11,7 @@ class RenbanConstraint extends Constraint {
     alreadyAddedCardinalityConstraints: Uint8Array;
 
     constructor(board: Board, params: { cells: CellIndex[] }, constraintName: string, specificName: string) {
-        super(constraintName, specificName);
+        super(constraintName, specificName, params.cells.slice());
         this.cells = params.cells.slice();
         // TODO: When cardinality constraints can be added natively to the board, we should be able to deduplicate better
         this.alreadyAddedCardinalityConstraints = new Uint8Array(board.size + 1);

--- a/src/solver/Constraint/RenbanConstraint.ts
+++ b/src/solver/Constraint/RenbanConstraint.ts
@@ -123,15 +123,12 @@ class RenbanConstraint extends Constraint {
         }
 
         let changed = ConstraintResult.UNCHANGED;
-        for (const cell of this.cells) {
-            const result = board.keepCellMask(cell, expand);
-            if (result === ConstraintResult.INVALID) {
-                return ConstraintResult.INVALID;
-            }
-            if (result === ConstraintResult.CHANGED) {
-                changed = ConstraintResult.CHANGED;
-            }
-        }
+        const result = board.newApplyCellMasks(
+            this.cells,
+            Array.from({ length: this.cells.length }, () => expand)
+        );
+        if (result === ConstraintResult.INVALID) return ConstraintResult.INVALID;
+        if (result === ConstraintResult.CHANGED) changed = ConstraintResult.CHANGED;
         return changed;
     }
 }

--- a/src/solver/Constraint/SandwichSumConstraint.ts
+++ b/src/solver/Constraint/SandwichSumConstraint.ts
@@ -26,7 +26,7 @@ export function register(constraintBuilder: ConstraintBuilder) {
                 // we are helping out the subboard by doing naked pair logic for them because tactics aren't run on subboards by default
                 // so it will not see this without our help. doing the naked pair logic lets subboards be pruned during a solve.
                 if (
-                    subboard.newApplyCellMasks(
+                    subboard.applyCellMasks(
                         allCells,
                         allCells.map((_, i) => (i === firstPos || i === secondPos ? crustsMask : nonCrustsMask))
                     ) === ConstraintResult.INVALID

--- a/src/solver/Constraint/SandwichSumConstraint.ts
+++ b/src/solver/Constraint/SandwichSumConstraint.ts
@@ -52,6 +52,9 @@ export function register(constraintBuilder: ConstraintBuilder) {
             }
         }
 
-        return new OrConstraint('Sandwich Sum', `Sandwich Sum ${params.value} at ${params.cell}`, board, { subboards: subboards });
+        return new OrConstraint('Sandwich Sum', `Sandwich Sum ${params.value} at ${params.cell}`, board, {
+            subboards: subboards,
+            cells: allCells.slice(),
+        });
     });
 }

--- a/src/solver/Constraint/SandwichSumConstraint.ts
+++ b/src/solver/Constraint/SandwichSumConstraint.ts
@@ -1,6 +1,7 @@
 import { Board } from '../Board';
 import ConstraintBuilder from '../ConstraintBuilder';
 import { CellIndex, parseEdgeClueCoords, valueBit } from '../SolveUtility';
+import { ConstraintResult } from './Constraint';
 import { FPuzzlesCell } from './FPuzzlesInterfaces';
 import { FixedSumConstraint } from './FixedSumConstraint';
 import { OrConstraint } from './OrConstraint';
@@ -24,8 +25,14 @@ export function register(constraintBuilder: ConstraintBuilder) {
                 // in the (i,j) branch, cells i and j can only be 1 and size, and 2-(size-1) otherwise
                 // we are helping out the subboard by doing naked pair logic for them because tactics aren't run on subboards by default
                 // so it will not see this without our help. doing the naked pair logic lets subboards be pruned during a solve.
-                for (let i = 0; i < board.size; ++i) {
-                    subboard.keepCellMask(allCells[i], i === firstPos || i === secondPos ? crustsMask : nonCrustsMask);
+                if (
+                    subboard.newApplyCellMasks(
+                        allCells,
+                        allCells.map((_, i) => (i === firstPos || i === secondPos ? crustsMask : nonCrustsMask))
+                    ) === ConstraintResult.INVALID
+                ) {
+                    subboard.release();
+                    continue;
                 }
 
                 // cells in between the crusts must sum to the given total

--- a/src/solver/Constraint/SkyscraperConstraint.ts
+++ b/src/solver/Constraint/SkyscraperConstraint.ts
@@ -61,7 +61,7 @@ export class SkyscraperConstraint extends Constraint {
         if (this.clue === 1) {
             const keepMask = valueBit(board.size);
             return {
-                result: board.newApplyCellMask(this.cells[0], keepMask),
+                result: board.applyCellMask(this.cells[0], keepMask),
                 deleteConstraints: [this],
             };
         }
@@ -72,7 +72,7 @@ export class SkyscraperConstraint extends Constraint {
         if (this.clue === board.size) {
             for (let v = 1; v <= board.size; ++v) {
                 const keepMask = valueBit(v);
-                const result = board.newApplyCellMask(this.cells[v - 1], keepMask);
+                const result = board.applyCellMask(this.cells[v - 1], keepMask);
                 if (result === ConstraintResult.INVALID) {
                     return ConstraintResult.INVALID;
                 }
@@ -86,7 +86,7 @@ export class SkyscraperConstraint extends Constraint {
                 const maxValue = board.size - this.clue + 1 + cellIndex;
                 if (maxValue < board.size) {
                     const keepMask = maskLowerOrEqual(maxValue);
-                    const result = board.newApplyCellMask(cell, keepMask);
+                    const result = board.applyCellMask(cell, keepMask);
                     if (result === ConstraintResult.INVALID) {
                         return ConstraintResult.INVALID;
                     }
@@ -312,7 +312,7 @@ export class SkyscraperConstraint extends Constraint {
             }
         }
 
-        return board.newApplyCellMasks(this.cells, keepMasks);
+        return board.applyCellMasks(this.cells, keepMasks);
     }
 
     static seenCount(values: CellValue[]): number {

--- a/src/solver/Constraint/SkyscraperConstraint.ts
+++ b/src/solver/Constraint/SkyscraperConstraint.ts
@@ -40,15 +40,16 @@ export class SkyscraperConstraint extends Constraint {
         const firstCellIndex = board.cellIndex(params.directionalCoords.row, params.directionalCoords.col);
         const directionOffset = board.cellIndex(params.directionalCoords.dRow, params.directionalCoords.dCol);
         const specificName = `Skyscraper ${params.clue} at ${cellName(firstCellIndex, board.size)}`;
-        super('Skyscraper', specificName);
+        const cells = [];
+        for (let i = 0; i < board.size; ++i) {
+            cells.push(firstCellIndex + i * directionOffset);
+        }
+        super('Skyscraper', specificName, cells.slice());
 
         this.clue = params.clue;
         this.cellStart = firstCellIndex;
 
-        this.cells = [];
-        for (let i = 0; i < board.size; ++i) {
-            this.cells.push(this.cellStart + i * directionOffset);
-        }
+        this.cells = cells;
         this.cellsLookup = new Set(this.cells);
 
         this.memoPrefix = `Skyscraper|${this.clue}|${this.cellStart}`;

--- a/src/solver/Constraint/SkyscraperConstraint.ts
+++ b/src/solver/Constraint/SkyscraperConstraint.ts
@@ -60,7 +60,7 @@ export class SkyscraperConstraint extends Constraint {
         if (this.clue === 1) {
             const keepMask = valueBit(board.size);
             return {
-                result: board.keepCellMask(this.cells[0], keepMask) ? ConstraintResult.CHANGED : ConstraintResult.UNCHANGED,
+                result: board.newApplyCellMask(this.cells[0], keepMask),
                 deleteConstraints: [this],
             };
         }
@@ -71,7 +71,7 @@ export class SkyscraperConstraint extends Constraint {
         if (this.clue === board.size) {
             for (let v = 1; v <= board.size; ++v) {
                 const keepMask = valueBit(v);
-                const result = board.keepCellMask(this.cells[v - 1], keepMask);
+                const result = board.newApplyCellMask(this.cells[v - 1], keepMask);
                 if (result === ConstraintResult.INVALID) {
                     return ConstraintResult.INVALID;
                 }
@@ -85,7 +85,7 @@ export class SkyscraperConstraint extends Constraint {
                 const maxValue = board.size - this.clue + 1 + cellIndex;
                 if (maxValue < board.size) {
                     const keepMask = maskLowerOrEqual(maxValue);
-                    const result = board.keepCellMask(cell, keepMask);
+                    const result = board.newApplyCellMask(cell, keepMask);
                     if (result === ConstraintResult.INVALID) {
                         return ConstraintResult.INVALID;
                     }
@@ -311,18 +311,7 @@ export class SkyscraperConstraint extends Constraint {
             }
         }
 
-        let changed = ConstraintResult.UNCHANGED;
-        for (let cellIndex = 0; cellIndex < this.cells.length; ++cellIndex) {
-            const result = board.keepCellMask(this.cells[cellIndex], keepMasks[cellIndex]);
-            if (result === ConstraintResult.INVALID) {
-                return ConstraintResult.INVALID;
-            }
-            if (result === ConstraintResult.CHANGED) {
-                changed = ConstraintResult.CHANGED;
-            }
-        }
-
-        return changed;
+        return board.newApplyCellMasks(this.cells, keepMasks);
     }
 
     static seenCount(values: CellValue[]): number {

--- a/src/solver/Constraint/WeakLinksConstraint.ts
+++ b/src/solver/Constraint/WeakLinksConstraint.ts
@@ -10,7 +10,11 @@ export class WeakLinksConstraint extends Constraint {
     weakLinks: [CandidateIndex, CandidateIndex][];
 
     constructor(board: Board, params: WeakLinksConstraintParams, name: string, specificName: string) {
-        super(name, specificName);
+        super(
+            name,
+            specificName,
+            params.weakLinks.flatMap(candidates => candidates.map(candidate => board.cellIndexFromCandidate(candidate)))
+        );
         this.weakLinks = params.weakLinks.slice();
     }
 

--- a/src/solver/Constraint/XSumConstraint.ts
+++ b/src/solver/Constraint/XSumConstraint.ts
@@ -1,6 +1,7 @@
 import { Board } from '../Board';
 import ConstraintBuilder from '../ConstraintBuilder';
 import { CellIndex, parseEdgeClueCoords, valueBit } from '../SolveUtility';
+import { ConstraintResult } from './Constraint';
 import { FPuzzlesCell } from './FPuzzlesInterfaces';
 import { FixedSumConstraint } from './FixedSumConstraint';
 import { OrConstraint } from './OrConstraint';
@@ -19,7 +20,11 @@ export function register(constraintBuilder: ConstraintBuilder) {
             const subboard = board.subboardClone();
 
             // In the ith branch, the first cell of the xsum has value i
-            subboard.keepCellMask(initialCellIndex, valueBit(digit));
+            if (subboard.newApplyCellMask(initialCellIndex, valueBit(digit)) === ConstraintResult.INVALID) {
+                subboard.release();
+                continue;
+            }
+
             // And the first i cells sum to the given total
             subboard.addConstraint(
                 new FixedSumConstraint(`Hypothetical X-Sum`, `Hypothetical X-Sum ${params.value} at ${params.cell} if X = ${digit}`, subboard, {

--- a/src/solver/Constraint/XSumConstraint.ts
+++ b/src/solver/Constraint/XSumConstraint.ts
@@ -36,6 +36,6 @@ export function register(constraintBuilder: ConstraintBuilder) {
             subboards.push(subboard);
         }
 
-        return new OrConstraint('X-Sum', `X-Sum ${params.value} at ${params.cell}`, board, { subboards: subboards });
+        return new OrConstraint('X-Sum', `X-Sum ${params.value} at ${params.cell}`, board, { subboards: subboards, cells: sumCells.slice() });
     });
 }

--- a/src/solver/Constraint/XSumConstraint.ts
+++ b/src/solver/Constraint/XSumConstraint.ts
@@ -20,7 +20,7 @@ export function register(constraintBuilder: ConstraintBuilder) {
             const subboard = board.subboardClone();
 
             // In the ith branch, the first cell of the xsum has value i
-            if (subboard.newApplyCellMask(initialCellIndex, valueBit(digit)) === ConstraintResult.INVALID) {
+            if (subboard.applyCellMask(initialCellIndex, valueBit(digit)) === ConstraintResult.INVALID) {
                 subboard.release();
                 continue;
             }

--- a/src/solver/LogicalStep/CellForcing.ts
+++ b/src/solver/LogicalStep/CellForcing.ts
@@ -31,7 +31,7 @@ export class CellForcing extends LogicalStep {
                 if (desc) {
                     desc.push(`Cell Forcing: ${maskToString(cellMask, size)}${cellName(cellIndex, size)} => ${board.describeElims(elims)}.`);
                 }
-                return board.newApplyElims(elims) as number as LogicResult;
+                return board.applyElims(elims) as number as LogicResult;
             }
         }
     }

--- a/src/solver/LogicalStep/CellForcing.ts
+++ b/src/solver/LogicalStep/CellForcing.ts
@@ -31,7 +31,7 @@ export class CellForcing extends LogicalStep {
                 if (desc) {
                     desc.push(`Cell Forcing: ${maskToString(cellMask, size)}${cellName(cellIndex, size)} => ${board.describeElims(elims)}.`);
                 }
-                return board.performElims(elims);
+                return board.newApplyElims(elims) as number as LogicResult;
             }
         }
     }

--- a/src/solver/LogicalStep/Fish.ts
+++ b/src/solver/LogicalStep/Fish.ts
@@ -125,7 +125,7 @@ export class Fish extends LogicalStep {
                                         }${columnOrRowIndices} [${board.describeCandidates(fishCandidates.flat())}] => ${board.describeElims(elims)}.`
                                     );
                                 }
-                                return board.newApplyElims(elims) as number as LogicResult;
+                                return board.applyElims(elims) as number as LogicResult;
                             }
                         }
                     }

--- a/src/solver/LogicalStep/Fish.ts
+++ b/src/solver/LogicalStep/Fish.ts
@@ -11,7 +11,7 @@ export class Fish extends LogicalStep {
         this._enabledFish = enabledFish;
     }
 
-    step(board: Board, desc: string[] | null = null) {
+    step(board: Board, desc: string[] | null = null): LogicResult {
         const { size, cells } = board;
 
         // Construct a transformed lookup of which values are in which rows/cols
@@ -125,7 +125,7 @@ export class Fish extends LogicalStep {
                                         }${columnOrRowIndices} [${board.describeCandidates(fishCandidates.flat())}] => ${board.describeElims(elims)}.`
                                     );
                                 }
-                                return board.performElims(elims);
+                                return board.newApplyElims(elims) as number as LogicResult;
                             }
                         }
                     }

--- a/src/solver/LogicalStep/HiddenSingle.ts
+++ b/src/solver/LogicalStep/HiddenSingle.ts
@@ -46,7 +46,7 @@ export class HiddenSingle extends LogicalStep {
                 const newCellMask = cellMask & exactlyOnce;
                 if (newCellMask !== 0 && newCellMask != cellMask) {
                     const cellValue = minValue(newCellMask);
-                    if (board.newApplySingle(board.candidateIndex(cellIndex, cellValue)) === ConstraintResult.INVALID) {
+                    if (board.applySingle(board.candidateIndex(cellIndex, cellValue)) === ConstraintResult.INVALID) {
                         if (desc) {
                             desc.push(`Hidden Single in ${region.name}: ${cellName(cellIndex, size)} cannot be set to ${cellValue}.`);
                         }

--- a/src/solver/LogicalStep/HiddenSingle.ts
+++ b/src/solver/LogicalStep/HiddenSingle.ts
@@ -1,4 +1,5 @@
 import { Board } from '../Board';
+import { ConstraintResult } from '../Constraint/Constraint';
 import { LogicResult } from '../Enums/LogicResult';
 import { cellName, maskToString, minValue } from '../SolveUtility';
 import { LogicalStep } from './LogicalStep';
@@ -45,7 +46,7 @@ export class HiddenSingle extends LogicalStep {
                 const newCellMask = cellMask & exactlyOnce;
                 if (newCellMask !== 0 && newCellMask != cellMask) {
                     const cellValue = minValue(newCellMask);
-                    if (!board.setAsGiven(cellIndex, cellValue)) {
+                    if (board.newApplySingle(board.candidateIndex(cellIndex, cellValue)) === ConstraintResult.INVALID) {
                         if (desc) {
                             desc.push(`Hidden Single in ${region.name}: ${cellName(cellIndex, size)} cannot be set to ${cellValue}.`);
                         }

--- a/src/solver/LogicalStep/NakedSingle.ts
+++ b/src/solver/LogicalStep/NakedSingle.ts
@@ -1,4 +1,5 @@
 import { Board } from '../Board';
+import { ConstraintResult } from '../Constraint/Constraint';
 import { LogicResult } from '../Enums/LogicResult';
 import { cellName, minValue } from '../SolveUtility';
 import { LogicalStep } from './LogicalStep';
@@ -16,7 +17,7 @@ export class NakedSingle extends LogicalStep {
             const mask = board.cells[cellIndex];
             if (mask & (mask - 1)) continue;
             const value = minValue(mask);
-            if (!board.setAsGiven(cellIndex, value)) {
+            if (board.newApplySingle(board.candidateIndex(cellIndex, value)) === ConstraintResult.INVALID) {
                 if (desc) {
                     desc.push(`Naked Single: ${cellName(cellIndex, size)} cannot be set to ${value}.`);
                 }

--- a/src/solver/LogicalStep/NakedSingle.ts
+++ b/src/solver/LogicalStep/NakedSingle.ts
@@ -17,7 +17,7 @@ export class NakedSingle extends LogicalStep {
             const mask = board.cells[cellIndex];
             if (mask & (mask - 1)) continue;
             const value = minValue(mask);
-            if (board.newApplySingle(board.candidateIndex(cellIndex, value)) === ConstraintResult.INVALID) {
+            if (board.applySingle(board.candidateIndex(cellIndex, value)) === ConstraintResult.INVALID) {
                 if (desc) {
                     desc.push(`Naked Single: ${cellName(cellIndex, size)} cannot be set to ${value}.`);
                 }

--- a/src/solver/LogicalStep/NakedSingle.ts
+++ b/src/solver/LogicalStep/NakedSingle.ts
@@ -9,38 +9,25 @@ export class NakedSingle extends LogicalStep {
     }
 
     step(board: Board, desc: string[] | null = null): LogicResult {
-        if (board.nakedSingles.length === 0) {
-            return LogicResult.UNCHANGED;
-        }
-
         const { size } = board;
 
         // Get the first naked single
-        board.nakedSingles.sort((a, b) => a - b);
-        const cellIndex = board.nakedSingles[0];
-        board.nakedSingles.shift();
-
-        // Get the value
-        const cellMask = board.cells[cellIndex];
-
-        // If this cell is already given then don't report it
-        if (cellMask & board.givenBit) {
-            return this.step(board, desc);
-        }
-
-        const cellValue = minValue(cellMask);
-
-        // Set the cell to the value
-        if (!board.setAsGiven(cellIndex, cellValue)) {
-            if (desc) {
-                desc.push(`Naked Single: ${cellName(cellIndex, size)} cannot be set to ${cellValue}.`);
+        for (let cellIndex = 0; cellIndex < size * size; cellIndex++) {
+            const mask = board.cells[cellIndex];
+            if (mask & (mask - 1)) continue;
+            const value = minValue(mask);
+            if (!board.setAsGiven(cellIndex, value)) {
+                if (desc) {
+                    desc.push(`Naked Single: ${cellName(cellIndex, size)} cannot be set to ${value}.`);
+                }
+                return LogicResult.INVALID;
             }
-            return LogicResult.INVALID;
+            if (desc) {
+                desc.push(`Naked Single: ${cellName(cellIndex, size)} = ${value}.`);
+            }
+            return LogicResult.CHANGED;
         }
 
-        if (desc) {
-            desc.push(`Naked Single: ${cellName(cellIndex, size)} = ${cellValue}.`);
-        }
-        return LogicResult.CHANGED;
+        return LogicResult.UNCHANGED;
     }
 }

--- a/src/solver/LogicalStep/NakedTupleAndPointing.ts
+++ b/src/solver/LogicalStep/NakedTupleAndPointing.ts
@@ -8,7 +8,7 @@ export class NakedTupleAndPointing extends LogicalStep {
         super('Naked Tuple and Pointing');
     }
 
-    step(board: Board, desc: string[] | null = null) {
+    step(board: Board, desc: string[] | null = null): LogicResult {
         const { size, cells } = board;
         for (let tupleSize = 2; tupleSize < size; tupleSize++) {
             for (const region of board.regions) {
@@ -85,7 +85,7 @@ export class NakedTupleAndPointing extends LogicalStep {
                     }
 
                     // Perform the eliminations
-                    return board.performElims(elims);
+                    return board.newApplyElims(elims) as number as LogicResult;
                 }
             }
 
@@ -121,7 +121,7 @@ export class NakedTupleAndPointing extends LogicalStep {
                     }
 
                     // Perform the eliminations
-                    return board.performElims(elims);
+                    return board.newApplyElims(elims) as number as LogicResult;
                 }
             }
         }

--- a/src/solver/LogicalStep/NakedTupleAndPointing.ts
+++ b/src/solver/LogicalStep/NakedTupleAndPointing.ts
@@ -85,7 +85,7 @@ export class NakedTupleAndPointing extends LogicalStep {
                     }
 
                     // Perform the eliminations
-                    return board.newApplyElims(elims) as number as LogicResult;
+                    return board.applyElims(elims) as number as LogicResult;
                 }
             }
 
@@ -121,7 +121,7 @@ export class NakedTupleAndPointing extends LogicalStep {
                     }
 
                     // Perform the eliminations
-                    return board.newApplyElims(elims) as number as LogicResult;
+                    return board.applyElims(elims) as number as LogicResult;
                 }
             }
         }

--- a/src/solver/LogicalStep/SimpleContradiction.ts
+++ b/src/solver/LogicalStep/SimpleContradiction.ts
@@ -1,4 +1,5 @@
 import { minValue, valueBit } from '../SolveUtility';
+import { ConstraintResult } from '../Constraint/Constraint';
 import { LogicResult } from '../Enums/LogicResult';
 import { Board } from '../Board';
 import { LogicalStep } from './LogicalStep';
@@ -38,11 +39,11 @@ export class SimpleContradiction extends LogicalStep {
 
                 // Check if this value is a contradiction
                 const newBoard = board.clone();
-                if (!newBoard.setAsGiven(cellIndex, value)) {
+                if (newBoard.newApplySingle(board.candidateIndex(cellIndex, value)) === ConstraintResult.INVALID) {
                     if (desc) {
                         desc.push(`Simple Contradiction: ${board.describeCandidates([candidateIndex])} causes a trivial contradiction.`);
                     }
-                    if (!board.clearValue(cellIndex, value)) {
+                    if (board.newApplyElim(board.candidateIndex(cellIndex, value)) === ConstraintResult.INVALID) {
                         return LogicResult.INVALID;
                     }
                     return LogicResult.CHANGED;
@@ -61,7 +62,7 @@ export class SimpleContradiction extends LogicalStep {
                                     ])} causes the following contradiction:\n • ${subDesc!.join('\n • ')}`
                                 );
                             }
-                            if (!board.clearValue(cellIndex, value)) {
+                            if (board.newApplyElim(board.candidateIndex(cellIndex, value)) === ConstraintResult.INVALID) {
                                 return LogicResult.INVALID;
                             }
                             return LogicResult.CHANGED;

--- a/src/solver/LogicalStep/SimpleContradiction.ts
+++ b/src/solver/LogicalStep/SimpleContradiction.ts
@@ -39,11 +39,11 @@ export class SimpleContradiction extends LogicalStep {
 
                 // Check if this value is a contradiction
                 const newBoard = board.clone();
-                if (newBoard.newApplySingle(board.candidateIndex(cellIndex, value)) === ConstraintResult.INVALID) {
+                if (newBoard.applySingle(board.candidateIndex(cellIndex, value)) === ConstraintResult.INVALID) {
                     if (desc) {
                         desc.push(`Simple Contradiction: ${board.describeCandidates([candidateIndex])} causes a trivial contradiction.`);
                     }
-                    if (board.newApplyElim(board.candidateIndex(cellIndex, value)) === ConstraintResult.INVALID) {
+                    if (board.applyElim(board.candidateIndex(cellIndex, value)) === ConstraintResult.INVALID) {
                         return LogicResult.INVALID;
                     }
                     return LogicResult.CHANGED;
@@ -62,7 +62,7 @@ export class SimpleContradiction extends LogicalStep {
                                     ])} causes the following contradiction:\n • ${subDesc!.join('\n • ')}`
                                 );
                             }
-                            if (board.newApplyElim(board.candidateIndex(cellIndex, value)) === ConstraintResult.INVALID) {
+                            if (board.applyElim(board.candidateIndex(cellIndex, value)) === ConstraintResult.INVALID) {
                                 return LogicResult.INVALID;
                             }
                             return LogicResult.CHANGED;

--- a/src/solver/LogicalStep/Skyscraper.ts
+++ b/src/solver/LogicalStep/Skyscraper.ts
@@ -1,4 +1,5 @@
 import { Board } from '../Board';
+import { ConstraintResult } from '../Constraint/Constraint';
 import { LogicResult } from '../Enums/LogicResult';
 import { combinations, ctz, popcount, valueBit } from '../SolveUtility';
 import { LogicalStep } from './LogicalStep';
@@ -42,8 +43,8 @@ export class Skyscraper extends LogicalStep {
                                     ? board.candidateIndexRC(rows[1].row, col1, value)
                                     : board.candidateIndexRC(col1, rows[1].row, value);
                             const elims = board.calcElimsForCandidateIndices([candidate0, candidate1]);
-                            const result = board.performElims(elims);
-                            if (result !== LogicResult.UNCHANGED) {
+                            const result = board.newApplyElims(elims);
+                            if (result !== ConstraintResult.UNCHANGED) {
                                 if (desc) {
                                     const sharedCol = ctz(rowMask0 & rowMask1);
                                     const sharedCandidate0 =
@@ -63,7 +64,7 @@ export class Skyscraper extends LogicalStep {
                                         ])} => ${board.describeElims(elims)}`
                                     );
                                 }
-                                return result;
+                                return result as number as LogicResult;
                             }
                         }
                     }

--- a/src/solver/LogicalStep/Skyscraper.ts
+++ b/src/solver/LogicalStep/Skyscraper.ts
@@ -43,7 +43,7 @@ export class Skyscraper extends LogicalStep {
                                     ? board.candidateIndexRC(rows[1].row, col1, value)
                                     : board.candidateIndexRC(col1, rows[1].row, value);
                             const elims = board.calcElimsForCandidateIndices([candidate0, candidate1]);
-                            const result = board.newApplyElims(elims);
+                            const result = board.applyElims(elims);
                             if (result !== ConstraintResult.UNCHANGED) {
                                 if (desc) {
                                     const sharedCol = ctz(rowMask0 & rowMask1);

--- a/src/solver/SolveUtility.ts
+++ b/src/solver/SolveUtility.ts
@@ -545,10 +545,11 @@ export function sequenceRemoveUpdateDefaultCompare<T>(arr1Inout: T[], arr2: read
     arr1Inout.length = iWrite;
 }
 
-export function sequenceExtend<T>(arr1Inout: T[], arr2: readonly T[]) {
+export function sequenceExtend<T>(arr1Inout: T[], arr2: readonly T[]): T[] {
     for (const elem of arr2) {
         arr1Inout.push(elem);
     }
+    return arr1Inout;
 }
 
 // Assumes arr is sorted

--- a/src/solver/SumGroup.ts
+++ b/src/solver/SumGroup.ts
@@ -348,14 +348,7 @@ export class SumGroup {
     }
 
     applySumResult(board: Board, resultMasks: CellMask[]): boolean {
-        for (let cellIndex = 0; cellIndex < this.cells.length; cellIndex++) {
-            const cell = this.cells[cellIndex];
-            if (board.keepCellMask(cell, resultMasks[cellIndex]) === ConstraintResult.INVALID) {
-                return false;
-            }
-        }
-
-        return true;
+        return board.newApplyCellMasks(this.cells, resultMasks) !== ConstraintResult.INVALID;
     }
 
     possibleSums(board: Board): number[] {

--- a/src/solver/SumGroup.ts
+++ b/src/solver/SumGroup.ts
@@ -348,7 +348,7 @@ export class SumGroup {
     }
 
     applySumResult(board: Board, resultMasks: CellMask[]): boolean {
-        return board.newApplyCellMasks(this.cells, resultMasks) !== ConstraintResult.INVALID;
+        return board.applyCellMasks(this.cells, resultMasks) !== ConstraintResult.INVALID;
     }
 
     possibleSums(board: Board): number[] {


### PR DESCRIPTION
keepCellMask and setAsGiven used to be mutually recursive, which made it difficult to experiment with non-transitive probing (NHBR). While the experiment didn't work out, the refactor to make it a single function (applyAndPropagate) is probably still a good idea and makes the code cleaner.

On top of this change, constraints are also only triggered if cells involving that constraint updated, or if an implication is added. This decreased the cost of negative literal probing, but that was yet another experiment that didn't work out.